### PR TITLE
fix: get_request_body more robust 

### DIFF
--- a/restlogger/middleware.py
+++ b/restlogger/middleware.py
@@ -112,10 +112,8 @@ class RESTRequestLoggingMiddleware:
         try:
             body = json.loads(cached_request_body)
             mask_sensitive_data(body)
-        except JSONDecodeError:
-            body = "Not a JSON body"
-        except AttributeError:
-            body = {}
+        except Exception:
+            body = {"info": "Could not read body"}
 
         return body
 


### PR DESCRIPTION
This pull request updates the error handling logic in the `_get_request_body` method of `restlogger/middleware.py` to improve robustness and consistency when parsing request bodies.

Error handling improvements:

* The method now catches all exceptions during JSON parsing and returns a dictionary with an informative message (`{"info": "Could not read body"}`) instead of returning a string or an empty dictionary for specific error types. This ensures the return type is always a dictionary and provides clearer error information.…nary with info message